### PR TITLE
Use python_realpath instead realpath(1) command

### DIFF
--- a/libexec/ptero-deploy-deis-scale
+++ b/libexec/ptero-deploy-deis-scale
@@ -7,7 +7,7 @@ if [ ! -f "$1" ]; then
     exit 1
 fi
 
-CONFIG_FILE=$(realpath $1)
+CONFIG_FILE=$(python_realpath $1)
 
 log "Scaling apps..."
 log


### PR DESCRIPTION
I'm pretty sure we meant to use `python_realpath` here, but missed it during review.