### PR TITLE
Allow one to specify lsf configuration to source

### DIFF
--- a/libexec/ptero-deploy-lsf-job-status-updater
+++ b/libexec/ptero-deploy-lsf-job-status-updater
@@ -11,6 +11,13 @@ if [ ! -f "$1" ]; then
     exit 1
 fi
 
+if [ ! -f "$2" ]; then
+    log "Must specify a lsf configuration to source"
+    exit 1
+else
+    source $2
+fi
+
 CONFIG_FILE=$(python_realpath $1)
 SERVICE='"lsf"'
 

--- a/libexec/ptero-deploy-lsf-job-submitter
+++ b/libexec/ptero-deploy-lsf-job-submitter
@@ -11,6 +11,13 @@ if [ ! -f "$1" ]; then
     exit 1
 fi
 
+if [ ! -f "$2" ]; then
+    log "Must specify a lsf configuration to source"
+    exit 1
+else
+    source $2
+fi
+
 CONFIG_FILE=$(python_realpath $1)
 SERVICE='"lsf"'
 


### PR DESCRIPTION
This keeps us from adding an additional process layer and needing to
pass along SIGTERM in that layer.