### PR TITLE
Sind QUIT to celery processes instead of TERM

### DIFF
--- a/libexec/workers-common
+++ b/libexec/workers-common
@@ -1,4 +1,4 @@
-trap 'kill -TERM $PID; wait $PID' TERM INT
+trap 'kill -QUIT $PID; wait $PID' TERM INT
 
 USAGE="Usage: $0 DEPLOYMENT_CONFIG"
 DEPLOYMENT_CONFIG=${1?"$USAGE"}


### PR DESCRIPTION
TERM is a warm shutdown signal wheras QUIT is cold shutdown.  We want
them to shutdown ASAP.