### PR TITLE
Allow 504 response from posting to deis.

### DIFF
--- a/libexec/deploy-deis-proxy
+++ b/libexec/deploy-deis-proxy
@@ -161,17 +161,28 @@ class DeisProxy(object):
                 'Failed to update scale for %s:\n%s' % (app_name, scale))
 
     def _deis_get(self, endpoint):
-        response = get(self._endpoint_url(endpoint), headers=self._auth_header)
+        response = get(self._endpoint_url(endpoint),
+                headers=self._auth_header)
         response.raise_for_status()
         return response.json()
 
-    def _deis_post(self, endpoint, data):
+    def _deis_post(self, endpoint, data, allowed_status_codes=[504]):
         headers = self._auth_header
         headers.update({'Content-Type': 'application/json'})
-        response = post(self._endpoint_url(endpoint), json=data, headers=headers)
-        response.raise_for_status()
-        if response.encoding == 'application/json':
-            return response.json()
+        response = post(self._endpoint_url(endpoint),
+                    json=data, headers=headers)
+
+        if response.status_code in allowed_status_codes:
+            print "Note: got allowed status_code (%s) from POST to %s" % (
+                    response.status_code,
+                    self._endpoint_url(endpoint))
+            return None
+        else:
+            response.raise_for_status()
+            if response.encoding == 'application/json':
+                return response.json()
+            else:
+                return response.content
 
     def _endpoint_url(self, endpoint):
         return self._controller_url + endpoint


### PR DESCRIPTION
Deis has some timeout set that we have not been able to configure that
causes 504 responses when we try to set the configuration for a deis
app.  The configuration we post does get set, but the 504 was preventing
the code from considering it a success.
